### PR TITLE
Limelight Vector bug fix

### DIFF
--- a/src/main/java/frc/robot/constants/RobotConstants.java
+++ b/src/main/java/frc/robot/constants/RobotConstants.java
@@ -23,14 +23,15 @@ public abstract class RobotConstants extends RobotMap {
         public PIDSettings exampleSettings;
         public PIDSettings visionRotationSettings;
         public PIDSettings visionDistanceSettings;
-    }
 
+    }
     public static class VisionConstants {
         public double DISTANCE_CALCULATION_A_COEFFICIENT;
         public double DISTANCE_CALCULATION_B_COEFFICIENT;
         // Offsets are measured from the robot's center of rotation to the limelight position.
         public double LIMELIGHT_OFFSET_X;
         public double LIMELIGHT_OFFSET_Y;
+        public double LIMELIGHT_ANGLE_OFFSET;
         public double TARGET_NOT_FOUND_WAIT_TIME;
     }
 

--- a/src/main/java/frc/robot/constants/RobotConstants.java
+++ b/src/main/java/frc/robot/constants/RobotConstants.java
@@ -23,8 +23,8 @@ public abstract class RobotConstants extends RobotMap {
         public PIDSettings exampleSettings;
         public PIDSettings visionRotationSettings;
         public PIDSettings visionDistanceSettings;
-
     }
+
     public static class VisionConstants {
         public double DISTANCE_CALCULATION_A_COEFFICIENT;
         public double DISTANCE_CALCULATION_B_COEFFICIENT;

--- a/src/main/java/frc/robot/constants/robots/RobotA.java
+++ b/src/main/java/frc/robot/constants/robots/RobotA.java
@@ -24,6 +24,7 @@ public class RobotA extends RobotConstants {
         visionConstants.DISTANCE_CALCULATION_B_COEFFICIENT = 0;
         visionConstants.LIMELIGHT_OFFSET_X = 0;
         visionConstants.LIMELIGHT_OFFSET_Y = 0;
+        visionConstants.LIMELIGHT_ANGLE_OFFSET = 0;
         visionConstants.TARGET_NOT_FOUND_WAIT_TIME = 0.1;
 
         pidConstants.exampleSettings = new PIDSettings(0,0,0,0);

--- a/src/main/java/frc/robot/vision/Limelight.java
+++ b/src/main/java/frc/robot/vision/Limelight.java
@@ -4,6 +4,7 @@ import edu.wpi.first.networktables.NetworkTable;
 import edu.wpi.first.networktables.NetworkTableEntry;
 import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.wpilibj.drive.Vector2d;
+import frc.robot.Robot;
 import frc.robot.enums.CamMode;
 import frc.robot.enums.LedMode;
 import frc.robot.enums.Target;
@@ -206,5 +207,15 @@ public class Limelight {
     limelightToTarget.rotate(getTx());
     // The offset is subtracted from the limelightToTarget vector in order to get the final vector.
     return new Vector2d(middleToLimelight.x + limelightToTarget.x, middleToLimelight.y + limelightToTarget.y);
+  }
+  public static void main(String[] args){
+    //This is the offset vector.
+    Vector2d middleToLimelight = new Vector2d(-0, -0);
+    //This is the the vector from the limelight to the target.
+    Vector2d limelightToTarget = new Vector2d(10, 0);
+    limelightToTarget.rotate(46);
+    // The offset is subtracted from the limelightToTarget vector in order to get the final vector.
+    Vector2d v = new Vector2d(middleToLimelight.x + limelightToTarget.x, middleToLimelight.y + limelightToTarget.y);
+    System.out.println("magnitude: " + limelightToTarget.magnitude() + ", angle: " + Math.toDegrees(Math.atan(limelightToTarget.y/limelightToTarget.x)));
   }
 }

--- a/src/main/java/frc/robot/vision/Limelight.java
+++ b/src/main/java/frc/robot/vision/Limelight.java
@@ -93,7 +93,7 @@ public class Limelight {
    */
   public double getAngle() {
     Vector2d vector = calculateVector();
-    return Math.atan(vector.y / vector.x);
+    return Math.toDegrees(Math.atan(vector.y / vector.x));
   }
 
   /**

--- a/src/main/java/frc/robot/vision/Limelight.java
+++ b/src/main/java/frc/robot/vision/Limelight.java
@@ -4,7 +4,6 @@ import edu.wpi.first.networktables.NetworkTable;
 import edu.wpi.first.networktables.NetworkTableEntry;
 import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.wpilibj.drive.Vector2d;
-import frc.robot.Robot;
 import frc.robot.enums.CamMode;
 import frc.robot.enums.LedMode;
 import frc.robot.enums.Target;
@@ -191,7 +190,7 @@ public class Limelight {
   /**
    * Stops the vision calculation, turns off led and change the camera to driver mode.
    */
-  public void stopVision(){
+  public void stopVision() {
     setCamMode(CamMode.driver);
     setLedMode(LedMode.off);
   }
@@ -201,21 +200,10 @@ public class Limelight {
    */
   private Vector2d calculateVector() {
     //This is the offset vector.
-    Vector2d middleToLimelight = new Vector2d(-robotConstants.visionConstants.LIMELIGHT_OFFSET_X, -robotConstants.visionConstants.LIMELIGHT_OFFSET_Y);
     //This is the the vector from the limelight to the target.
-    Vector2d limelightToTarget = new Vector2d(0, getDistanceFromLimelight());
+    Vector2d limelightToTarget = new Vector2d(getDistanceFromLimelight(), 0);
     limelightToTarget.rotate(getTx());
     // The offset is subtracted from the limelightToTarget vector in order to get the final vector.
-    return new Vector2d(middleToLimelight.x + limelightToTarget.x, middleToLimelight.y + limelightToTarget.y);
-  }
-  public static void main(String[] args){
-    //This is the offset vector.
-    Vector2d middleToLimelight = new Vector2d(-0, -0);
-    //This is the the vector from the limelight to the target.
-    Vector2d limelightToTarget = new Vector2d(10, 0);
-    limelightToTarget.rotate(46);
-    // The offset is subtracted from the limelightToTarget vector in order to get the final vector.
-    Vector2d v = new Vector2d(middleToLimelight.x + limelightToTarget.x, middleToLimelight.y + limelightToTarget.y);
-    System.out.println("magnitude: " + limelightToTarget.magnitude() + ", angle: " + Math.toDegrees(Math.atan(limelightToTarget.y/limelightToTarget.x)));
+    return new Vector2d(limelightToTarget.x - robotConstants.visionConstants.LIMELIGHT_OFFSET_X, limelightToTarget.y - robotConstants.visionConstants.LIMELIGHT_OFFSET_Y);
   }
 }

--- a/src/main/java/frc/robot/vision/Limelight.java
+++ b/src/main/java/frc/robot/vision/Limelight.java
@@ -199,7 +199,6 @@ public class Limelight {
    * @return the vector between the middle of the robot and and the target.
    */
   private Vector2d calculateVector() {
-    //This is the offset vector.
     //This is the the vector from the limelight to the target.
     Vector2d limelightToTarget = new Vector2d(getDistanceFromLimelight(), 0);
     limelightToTarget.rotate(getTx());

--- a/src/main/java/frc/robot/vision/Limelight.java
+++ b/src/main/java/frc/robot/vision/Limelight.java
@@ -201,7 +201,7 @@ public class Limelight {
   private Vector2d calculateVector() {
     //This is the the vector from the limelight to the target.
     Vector2d limelightToTarget = new Vector2d(getDistanceFromLimelight(), 0);
-    limelightToTarget.rotate(getTx());
+    limelightToTarget.rotate(getTx() + robotConstants.visionConstants.LIMELIGHT_ANGLE_OFFSET);
     // The offset is subtracted from the limelightToTarget vector in order to get the final vector.
     return new Vector2d(limelightToTarget.x - robotConstants.visionConstants.LIMELIGHT_OFFSET_X, limelightToTarget.y - robotConstants.visionConstants.LIMELIGHT_OFFSET_Y);
   }

--- a/src/main/java/frc/robot/vision/Limelight.java
+++ b/src/main/java/frc/robot/vision/Limelight.java
@@ -72,7 +72,7 @@ public class Limelight {
   }
 
   /**
-   * @return The distance between the the target and the limelight
+   * @return The distance between the target and the limelight
    */
   //TODO: set real function
   public double getDistanceFromLimelight() {
@@ -82,7 +82,7 @@ public class Limelight {
   }
 
   /**
-   * @return The distance between the the target and the the middle of the robot
+   * @return The distance between the target and the middle of the robot
    */
   public double getDistance() {
     return calculateVector().magnitude();
@@ -196,10 +196,10 @@ public class Limelight {
   }
 
   /**
-   * @return the vector between the middle of the robot and and the target.
+   * @return the vector between the middle of the robot and the target.
    */
   private Vector2d calculateVector() {
-    //This is the the vector from the limelight to the target.
+    //This is the vector from the limelight to the target.
     Vector2d limelightToTarget = new Vector2d(getDistanceFromLimelight(), 0);
     limelightToTarget.rotate(getTx() + robotConstants.visionConstants.LIMELIGHT_ANGLE_OFFSET);
     // The offset is subtracted from the limelightToTarget vector in order to get the final vector.


### PR DESCRIPTION
Apparently, Vector2d is using X as the distance ahead of the robot, like Pose2d and all those classes.
I also added a limelight offset angle since it might be rotated and not parallel to the robot.